### PR TITLE
Some updates

### DIFF
--- a/Schemas/2023.11.09.0000.0000/Item.yml
+++ b/Schemas/2023.11.09.0000.0000/Item.yml
@@ -27,7 +27,7 @@ fields:
     type: array
     count: 6
   - name: LevelEquip
-  - name: Unknown1
+  - name: RequiredPvpRank
   - name: EquipRestriction
   - name: ClassJobCategory
     type: link

--- a/Schemas/2023.11.09.0000.0000/NotoriousMonsterTerritory.yml
+++ b/Schemas/2023.11.09.0000.0000/NotoriousMonsterTerritory.yml
@@ -1,12 +1,8 @@
 name: NotoriousMonsterTerritory
 fields:
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
-  - name: Unknown8
-  - name: Unknown9
+  - name: NotoriousMonsters
+    type: array
+    count: 10
+    fields:
+      - type: link
+        targets: [NotoriousMonster]

--- a/Schemas/2023.11.09.0000.0000/TerritoryType.yml
+++ b/Schemas/2023.11.09.0000.0000/TerritoryType.yml
@@ -36,7 +36,9 @@ fields:
     type: link
     targets: [QuestBattle]
   - name: Resident
-  - name: Unknown0
+  - name: NotoriousMonsterTerritory
+    type: link
+    targets: [NotoriousMonsterTerritory]
   - name: BattalionMode
   - name: LoadingImage
     type: link


### PR DESCRIPTION
I identified the following columns:

- **Item:** `Unknown1` => `RequiredPvpRank`
   Found at "1B C0 25 ?? ?? ?? ?? 48 8B 5C 24" (returns a LogMessage RowId for "Unable to equip at current PvP rank.")
- **TerritoryType:** `Unknown0` => `TerritoryType.NotoriousMonsterTerritory`
   Found at "E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ?? 48 8B 93 ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 48 8B 5C 24"
- **NotoriousMonsterTerritory**: All columns are links to the NotoriousMonster sheet
   Found after following the last sig into "48 89 5C 24 ?? 55 56 57 48 83 EC 50 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 44 24 ?? 48 8B 02"

I'm not sure how this works. Am I supposed to change the other Unknown columns names or not? I hope I did it right! 🙂