### PR TITLE
Update `Pet` and `PetMirage`

### DIFF
--- a/Schemas/2024.02.05.0000.0000/Pet.yml
+++ b/Schemas/2024.02.05.0000.0000/Pet.yml
@@ -5,13 +5,13 @@ fields:
   - name: Ability1
     type: link
     targets: [Action]
-  - name: Ability1
-    type: link
-    targets: [Action]
   - name: Ability2
     type: link
     targets: [Action]
   - name: Ability3
+    type: link
+    targets: [Action]
+  - name: Ability4
     type: link
     targets: [Action]
   - name: AutoAction

--- a/Schemas/2024.02.05.0000.0000/Pet.yml
+++ b/Schemas/2024.02.05.0000.0000/Pet.yml
@@ -2,14 +2,24 @@ name: Pet
 displayField: Name
 fields:
   - name: Name
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
+  - name: Ability1
+    type: link
+    targets: [Action]
+  - name: Ability1
+    type: link
+    targets: [Action]
+  - name: Ability2
+    type: link
+    targets: [Action]
+  - name: Ability3
+    type: link
+    targets: [Action]
+  - name: AutoAction
+    type: link
+    targets: [Action]
+  - name: SmallScalePercentage
+  - name: MediumScalePercentage
+  - name: LargeScalePercentage
   - name: Unknown8
   - name: Unknown9
   - name: Unknown10

--- a/Schemas/2024.02.05.0000.0000/Pet.yml
+++ b/Schemas/2024.02.05.0000.0000/Pet.yml
@@ -28,5 +28,5 @@ fields:
   - name: Unknown13
   - name: Unknown14
   - name: Unknown15
-  - name: Unknown16
+  - name: NonCombatSummon
   - name: Unknown17

--- a/Schemas/2024.02.05.0000.0000/Pet.yml
+++ b/Schemas/2024.02.05.0000.0000/Pet.yml
@@ -2,18 +2,12 @@ name: Pet
 displayField: Name
 fields:
   - name: Name
-  - name: Ability1
-    type: link
-    targets: [Action]
-  - name: Ability2
-    type: link
-    targets: [Action]
-  - name: Ability3
-    type: link
-    targets: [Action]
-  - name: Ability4
-    type: link
-    targets: [Action]
+  - name: Abilities
+    type: array
+    count: 4
+    fields:
+    - type: link
+      targets: [Action]
   - name: AutoAction
     type: link
     targets: [Action]

--- a/Schemas/2024.02.05.0000.0000/PetMirage.yml
+++ b/Schemas/2024.02.05.0000.0000/PetMirage.yml
@@ -62,5 +62,7 @@ fields:
   - name: Unknown57
   - name: Unknown58
   - name: Unknown59
-  - name: Unknown60
-  - name: Unknown61
+  - name: Scale
+  - name: ModelCharacterId
+    type: link
+    targets: [ModelChara]

--- a/Schemas/2024.02.05.0000.0000/PetMirage.yml
+++ b/Schemas/2024.02.05.0000.0000/PetMirage.yml
@@ -63,6 +63,6 @@ fields:
   - name: Unknown58
   - name: Unknown59
   - name: Scale
-  - name: ModelCharacterId
+  - name: ModelChara
     type: link
     targets: [ModelChara]


### PR DESCRIPTION
I couldn't quite figure out a good name for fields 15-17.
Unknown15 is true only for pets summoned by non-casters, like MCH's Automaton & Turrets and DRK's Esteem via Living Shadow.
Unknown16 is true only for summons you can summon out of combat, which are SMN's carbuncle and SCH's fairies.
Uknownk17 is true only for pets summoned by casters, although it doesn't make sense to have 2 fields for this, so I must be misinterpreting one of them.