### PR TITLE
Add SublimeVariant to GatheringItem

### DIFF
--- a/Schemas/2024.03.27.0000.0000/GatheringItem.yml
+++ b/Schemas/2024.03.27.0000.0000/GatheringItem.yml
@@ -11,9 +11,7 @@ fields:
   - name: GatheringItemLevel
     type: link
     targets: [GatheringItemLevelConvertTable]
-  - name: Quest
-    type: link
-    targets: [Quest]
+  - name: PerceptionReq
   - name: Unknown2
   - name: Unknown3
   - name: Unknown4

--- a/Schemas/2024.03.27.0000.0000/GatheringItem.yml
+++ b/Schemas/2024.03.27.0000.0000/GatheringItem.yml
@@ -2,7 +2,9 @@ name: GatheringItem
 displayField: Item
 fields:
   - name: Unknown0
-  - name: Unknown1
+  - name: SublimeVariant
+    type: link
+    targets: [GatheringItem]
   - name: Item
     type: link
     targets: [Item, EventItem]


### PR DESCRIPTION
SublimeVariant is used in some collectable items, it's a % based on collectability to obtain a higher grade item in the form of another item ID.

Inside the sheet, it's represented as a simple link to this other item's GatheringItem entry.

I'm not sure how parsers would react with this kind of recursive link but it's not the first one so it should be fine !

![image](https://github.com/xivdev/EXDSchema/assets/11519203/a3957212-986b-4a7e-bdd9-6157f99b31b7)

N.B: I also renamed Quest to PerceptionReq and removed the link because that's definitely not quest but the required perception value to gather the said item.
