### PR TITLE
Update TransientKey -> link to ContentUICategory in ContentFinderCondition

### DIFF
--- a/Schemas/2024.07.24.0000.0000/ContentFinderCondition.yml
+++ b/Schemas/2024.07.24.0000.0000/ContentFinderCondition.yml
@@ -55,7 +55,7 @@ fields:
   - name: Transient
     type: link
     condition:
-      switch: TransientKey
+      switch: ContentUICategory
       cases:
         6: [ContentFinderConditionTransient]
         7: [ContentFinderConditionTransient]

--- a/Schemas/2024.07.24.0000.0000/ContentFinderCondition.yml
+++ b/Schemas/2024.07.24.0000.0000/ContentFinderCondition.yml
@@ -99,7 +99,9 @@ fields:
   - name: ContentType
     type: link
     targets: [ContentType]
-  - name: TransientKey
+  - name: ContentUICategory
+    type: link
+    targets: [ContentUICategory]
   - name: Unknown40
   - name: Unknown41
   - name: PvP


### PR DESCRIPTION
This is my first commit to EXDSchema, and while the schema does make sense at first glance, I'm unsure of what to do with the `switch` on `TransientKey` for the `Transient` key. Let me know what I need to change for this part, though I suspect it might be because another field is supposed to be labelled TransientKey. I can look in a bit if that's the case.