### PR TITLE
Update ClassJobActionUI.yml

### DIFF
--- a/Schemas/2024.08.02.0000.0000/ClassJobActionUI.yml
+++ b/Schemas/2024.08.02.0000.0000/ClassJobActionUI.yml
@@ -1,7 +1,13 @@
 name: ClassJobActionUI
 fields:
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
+  - name: UpgradeAction
+    type: link
+    targets: [Action]
+  - name: BaseAction
+    type: link
+    targets: [Action]
+  - name: ComboTreeLayout
+    comment: Used to position the action within a combo tree diagram. Non-zero digits identify branches within the combo (eg, Hakaze -> Shifu -> Kasha is 100 -> 120 -> 121)
   - name: Unknown3
-  - name: Unknown4
+  - name: GroupedCell
+    comment: Currently only used for MNK actions; displays a set of actions in a shared rectangular cell instead of a tree.


### PR DESCRIPTION
This sheet governs aspects of how actions are displayed in the "Actions & Traits" menu.
- **`UpgradeAction` (prev `Unknown0`):** The upgraded version of a given action. (An action with multiple upgrades will have a row for each upgrade)
- **`BaseAction` (prev `Unknown1`):** The base action being displayed.
- **`ComboTreeLayout` (prev `Unknown2`):** Used to position the action within a combo tree diagram. Non-zero digits identify branches within the combo (eg, `Hakaze -> Shifu -> Kasha` are arranged as `100 -> 120 -> 121`)
- **`GroupedCell` (prev `Unknown4`):** Currently only used for MNK actions; arranges a set of actions together within a rectangular cell, instead of as a tree.