### PR TITLE
Add PreHandler target to ENpcBase

### DIFF
--- a/Schemas/2024.08.02.0000.0000/ENpcBase.yml
+++ b/Schemas/2024.08.02.0000.0000/ENpcBase.yml
@@ -5,7 +5,7 @@ fields:
     count: 32
     fields:
       - type: link
-        targets: [ChocoboTaxiStand, CraftLeve, CustomTalk, DefaultTalk, FccShop, GCShop, GilShop, GuildleveAssignment, GuildOrderGuide, GuildOrderOfficer, Quest, SpecialShop, Story, SwitchTalk, TopicSelect, TripleTriad, Warp]
+        targets: [ChocoboTaxiStand, CraftLeve, CustomTalk, DefaultTalk, FccShop, GCShop, GilShop, GuildleveAssignment, GuildOrderGuide, GuildOrderOfficer, Quest, SpecialShop, Story, SwitchTalk, TopicSelect, TripleTriad, Warp, PreHandler]
   - name: ModelMainHand
   - name: ModelOffHand
   - name: Scale


### PR DESCRIPTION
Good example of this is, ENpcBase 1044549, has a reference to 3539067 which is a PreHandler. 