### PR TITLE
More UnlockLink columns and Perform schema fix

### DIFF
--- a/Schemas/2024.11.06.0000.0000/BuddyAction.yml
+++ b/Schemas/2024.11.06.0000.0000/BuddyAction.yml
@@ -7,5 +7,5 @@ fields:
     type: icon
   - name: IconStatus
     type: icon
-  - name: Reward
+  - name: UnlockLink
   - name: Sort

--- a/Schemas/2024.11.06.0000.0000/CSBonusContentType.yml
+++ b/Schemas/2024.11.06.0000.0000/CSBonusContentType.yml
@@ -13,7 +13,7 @@ fields:
   - name: UnlockQuest
     type: link
     targets: [Quest]
-  - name: Unknown11
+  - name: UnlockLink
   - name: Unknown12
   - name: ContentType
     type: link

--- a/Schemas/2024.11.06.0000.0000/CharaMakeCustomize.yml
+++ b/Schemas/2024.11.06.0000.0000/CharaMakeCustomize.yml
@@ -9,7 +9,7 @@ fields:
   - name: HintItem
     type: link
     targets: [Item]
-  - name: Data
+  - name: UnlockLink
   - name: FeatureID
   - name: Unknown0
   - name: IsPurchasable

--- a/Schemas/2024.11.06.0000.0000/MJILandmark.yml
+++ b/Schemas/2024.11.06.0000.0000/MJILandmark.yml
@@ -5,7 +5,7 @@ fields:
     targets: [MJIText]
   - name: Icon
     type: icon
-  - name: Unknown0
+  - name: UnlockLink
   - name: SGB
     type: array
     count: 7

--- a/Schemas/2024.11.06.0000.0000/Perform.yml
+++ b/Schemas/2024.11.06.0000.0000/Perform.yml
@@ -10,9 +10,7 @@ fields:
   - name: Instrument
   - name: ModelKey
   - name: Name
-  - name: StopAnimation
-    type: link
-    targets: [ActionTimeline]
+  - name: UnlockLink
   - name: Order
   - name: AnimationStart
     type: link
@@ -26,5 +24,7 @@ fields:
   - name: Transient
     type: link
     targets: [PerformTransient]
-  - name: Unknown0
+  - name: PerformGroup
+    type: link
+    targets: [PerformGroup]
   - name: Unknown1

--- a/Schemas/2024.11.06.0000.0000/Perform.yml
+++ b/Schemas/2024.11.06.0000.0000/Perform.yml
@@ -11,7 +11,8 @@ fields:
   - name: ModelKey
   - name: Name
   - name: UnlockLink
-  - name: Order
+  - name: Icon
+    type: icon
   - name: AnimationStart
     type: link
     targets: [ActionTimeline]


### PR DESCRIPTION
- `BuddyAction.Reward`, `CharaMakeCustomize.Data` and `Perform.StopAnimation` (all 0), which are all passed to `UIState.IsUnlockLinkUnlocked`, were renamed to `UnlockLink`.
- `Perform.Order` is actually an icon id.