### PR TITLE
Rename Unknown0 in TomestonesItem sheet

### DIFF
--- a/TomestonesItem.yml
+++ b/TomestonesItem.yml
@@ -7,4 +7,4 @@ fields:
   - name: Tomestones
     type: link
     targets: [Tomestones]
-  - name: Unknown0
+  - name: CurrencyInventorySlot

--- a/TomestonesItem.yml
+++ b/TomestonesItem.yml
@@ -7,4 +7,5 @@ fields:
   - name: Tomestones
     type: link
     targets: [Tomestones]
-  - name: CurrencyInventorySlot
+  - name: Unknown0
+    pendingName: CurrencyInventorySlot


### PR DESCRIPTION
 - This renames the Unknown0 field in TomestonesItem. It's a reference to the inventory slot that the currency is stored in in bag 2000. When it's -1 it appears to refer to a field within InventoryManager and if it matches the Item in the TomestonesItem it'll then pull a count from another field in InventoryManager