### PR TITLE
Add AllVistasCompletedScreenImage to AdventureExPhase

### DIFF
--- a/AdventureExPhase.yml
+++ b/AdventureExPhase.yml
@@ -10,6 +10,23 @@ fields:
     type: link
     targets: [Adventure]
   - name: Unknown0
+    pendingName: AllVistasCompletedScreenImage
+  - name: Expansion
+    type: link
+    targets: [ExVersion]
+pendingFields:
+  - name: Quest
+    type: link
+    targets: [Quest]
+  - name: AdventureBegin
+    type: link
+    targets: [Adventure]
+  - name: AdventureEnd
+    type: link
+    targets: [Adventure]
+  - name: AllVistasCompletedScreenImage
+    type: link
+    targets: [ScreenImage]
   - name: Expansion
     type: link
     targets: [ExVersion]


### PR DESCRIPTION
Used in sub_1418d3810[^1] which is called when a vista is marked as completed, and gets this value from sub_1409982d0[^2] and then passes it to sub_141738d70[^3], eventually Client::UI::RaptureAtkModule.ShowScreenImage.

[^1]: `4C 8B DC 55 57 41 56 49 8D 6B ?? 48 81 EC D0 00 00 00`
[^2]: `40 53 48 83 EC 20 8B CA 49 8B D8 E8 ?? ?? ?? ?? 85 C0`
[^3]: `40 53 48 83 EC 20 8B DA E8 ?? ?? ?? ?? 48 8B C8 33 D2 E8 ?? ?? ?? ?? E8`