### PR TITLE
Update ZoneSharedGroup, TerritoryType

### DIFF
--- a/TerritoryType.yml
+++ b/TerritoryType.yml
@@ -56,6 +56,90 @@ fields:
     targets: [ExVersion]
   - name: Unknown2
   - name: Unknown3
+    pendingName: ZoneSharedGroup
+  - name: AetherCurrentCompFlgSet
+    type: link
+    targets: [AetherCurrentCompFlgSet]
+  - name: MountSpeed
+    type: link
+    targets: [MountSpeed]
+  - name: IndividualWeather
+    type: link
+    targets: [IndividualWeather]
+  - name: AchievementIndex
+  - name: Unknown6
+  - name: Unknown7
+  - name: PCSearch
+  - name: Stealth
+  - name: Mount
+  - name: Unknown8
+  - name: IsPvpZone
+  - name: Unknown9
+  - name: Unknown10
+  - name: Unknown11
+  - name: Unknown12
+  - name: Unknown13
+  - name: Unknown14
+  - name: Unknown15
+  - name: Unknown16
+pendingFields:
+  - name: Name
+  - name: Bg
+  - name: ArrayEventHandler
+    type: link
+    targets: [ArrayEventHandler]
+  - name: PlaceNameRegionIcon
+    type: icon
+  - name: PlaceNameIcon
+    type: icon
+  - name: Aetheryte
+    type: link
+    targets: [Aetheryte]
+  - name: FixedTime
+  - name: PlaceNameRegion
+    type: link
+    targets: [PlaceName]
+  - name: PlaceNameZone
+    type: link
+    targets: [PlaceName]
+  - name: PlaceName
+    type: link
+    targets: [PlaceName]
+  - name: Map
+    type: link
+    targets: [Map]
+  - name: ContentFinderCondition
+    type: link
+    targets: [ContentFinderCondition]
+  - name: BGM
+    type: link
+    targets: [BGM, BGMSituation]
+  - name: QuestBattle
+    type: link
+    targets: [QuestBattle]
+  - name: Resident
+  - name: NotoriousMonsterTerritory
+    type: link
+    targets: [NotoriousMonsterTerritory]
+  - name: BattalionMode
+  - name: LoadingImage
+    type: link
+    targets: [LoadingImage]
+  - name: ExclusiveType
+  - name: TerritoryIntendedUse
+    type: link
+    targets: [TerritoryIntendedUse]
+  - name: WeatherRate
+    type: link
+    targets: [WeatherRate]
+  - name: Unknown1
+  - name: ExVersion
+    type: link
+    targets: [ExVersion]
+  - name: Unknown2
+  - name: ZoneSharedGroup
+    type: link
+    targets: [ZoneSharedGroup]
   - name: AetherCurrentCompFlgSet
     type: link
     targets: [AetherCurrentCompFlgSet]

--- a/ZoneSharedGroup.yml
+++ b/ZoneSharedGroup.yml
@@ -41,3 +41,33 @@ fields:
   - name: Unknown13
   - name: Unknown14
   - name: Unknown15
+pendingFields:
+  - name: LGBSharedGroup
+  - name: RequirementRow
+    type: array
+    count: 6
+    fields:
+      - type: link
+        targets: [Quest, AetherCurrent, EurekaStoryProgress, DomaStoryProgress]
+  - name: Unknown0
+  - name: RequirementQuestSequence
+    type: array
+    count: 6
+  - name: Unknown1
+  - name: RequirementType
+    type: array
+    count: 6
+    comment: |
+      1 = Quest
+      2 = Quest with specific Sequence
+      3 = AetherCurrent
+      4 = EurekaStoryProgress
+      5 = DomaStoryProgress
+  - name: Unknown8
+  - name: Unknown9
+  - name: Unknown10
+  - name: Unknown11
+  - name: Unknown12
+  - name: Unknown13
+  - name: Unknown14
+  - name: Unknown15


### PR DESCRIPTION
**TerritoryType**

- `Unknown3` → `ZoneSharedGroup`: Found in `E8 ?? ?? ?? ?? 84 C0 74 45 C7 87`

**ZoneSharedGroup**

- `Quest0-6` → array `RequirementRow` with 6 items
- `Seq0-6` → array `RequirementQuestSequence` with 6 items
- `Unknown2-7` → array `RequirementType` with 6 items, can be one of:
	- 1 = Quest
	- 2 = Quest with specific Sequence
	- 3 = AetherCurrent
	- 4 = EurekaStoryProgress
	- 5 = DomaStoryProgress

This subrow sheet contains up to 6 requirements to enable the SharedGroup layout instance (LGBSharedGroup is its id).

Sadly, the fields are separated by an extra field, so I can't make it an array.

The RequirementTypes dictate the sheet the row ids (currently `Quest0-6`) reference, but I can't make it a condition due to the switch field being an element in another array.

If you have a better idea how to map this, I'm all ears!