### PR TITLE
Fix wrong example in Usage guide

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -24,7 +24,7 @@ If not, parsing should fail.
 
 We can define fields like this:
 ```yml
-type: sheet
+name: AozActionTransient
 fields:
   - name: Stats
   - name: Description


### PR DESCRIPTION
This had "type: sheet" defined, which isn't a thing anymore(?) Instead we should make it match the previous code block with a name field.