### PR TITLE
Update unknown field link in QuestRedoChapterUI

### DIFF
--- a/QuestRedoChapterUI.yml
+++ b/QuestRedoChapterUI.yml
@@ -8,6 +8,30 @@ fields:
     type: link
     targets: [Quest]
   - name: Unknown0
+    comment: Will be a link to Quest in the future
+  - name: QuestRedoUISmall
+    type: icon
+  - name: QuestRedoUILarge
+    type: icon
+  - name: QuestRedoUIWide
+    type: icon
+  - name: UITab
+    type: link
+    targets: [QuestRedoChapterUITab]
+  - name: Category
+    type: link
+    targets: [QuestRedoChapterUICategory]
+  - name: Unknown1
+pendingFields:
+  - name: ChapterName
+  - name: ChapterPart
+  - name: Transient
+  - name: Quest
+    type: link
+    targets: [Quest]
+  - name: Unknown0
+    type: link
+    targets: [Quest]
   - name: QuestRedoUISmall
     type: icon
   - name: QuestRedoUILarge


### PR DESCRIPTION
I'm still not certain what this is saying, but this is definitely a link to a quest. It's only used in the Shadowbringers role quests.