### PR TITLE
Update WeeklyBingoOrderData: Add WeeklyBingoMultipleOrder to the Data link switch

### DIFF
--- a/WeeklyBingoOrderData.yml
+++ b/WeeklyBingoOrderData.yml
@@ -7,6 +7,7 @@ fields:
       switch: Type
       cases:
         0: [InstanceContent]
+        4: [WeeklyBingoMultipleOrder]
   - name: Unknown2
   - name: Icon
     type: icon


### PR DESCRIPTION
This is how the game's new UI handles the pop-up in the WT UI that lists the applicable duties for things like "Alexander: Midas" or "AAC Cruiserweight M1 or M2". The Type for those sort of rows is 4 and the Data value is a row id for the new WeeklyBingoMultipleOrder sheet.