### PR TITLE
Add CharaCardDecoration Component

### DIFF
--- a/CharaCardDecoration.yml
+++ b/CharaCardDecoration.yml
@@ -11,7 +11,8 @@ fields:
   - name: Unknown_70_2
   - name: Unknown3
   - name: SortKey
-  - name: Unknown2
+  - name: Component
+    comment: 1 = Backing, 2 = Pattern Overlay, 3 = Portrait Frame, 4 = Plate Frame, 5 = Accent
   - name: Subtype
   - name: Unknown1
   - name: Category


### PR DESCRIPTION
Identifies the associated adventurer plate component as seen in the Edit Plate interface.

<img width="394" height="548" alt="image" src="https://github.com/user-attachments/assets/db97e5b0-380d-43ab-af82-3c4bf779a387" />
