### PR TITLE
Remove link from ItemAction.Data array

### DIFF
--- a/ItemAction.yml
+++ b/ItemAction.yml
@@ -6,21 +6,6 @@ fields:
   - name: Data
     type: array
     count: 9
-    fields:
-      - type: link
-        condition:
-          switch: Action
-          cases:
-            853: [Companion]
-            1013: [BuddyEquip]
-            1322: [Mount]
-            2136: [SecretRecipeBook]
-            2633: [CharaMakeCustomize]
-            3357: [TripleTriadCard]
-            4107: [GatheringSubCategory]
-            19743: [MYCWarResultNotebook]
-            20086: [Ornament]
-            43142: [MKDSupportJob]
   - name: DataHQ
     type: array
     count: 9


### PR DESCRIPTION
We've discussed this in the Dalamud Discord and others were the same opinion as I've stated in my [last ItemAction PR](https://github.com/xivdev/EXDSchema/pull/136):
It doesn't make sense to link the whole array to a sheet just because the first element happens to be a RowId.
I propose reverting this change to prioritize correctness, even at the cost of some usefulness.