### PR TITLE
Reorder Region field in World.yml

### DIFF
--- a/World.yml
+++ b/World.yml
@@ -5,6 +5,6 @@ fields:
   - name: DataCenter
     type: link
     targets: [WorldDCGroupType]
-  - name: Region
   - name: UserType
+  - name: Region
   - name: IsPublic


### PR DESCRIPTION
Follow-up to #137 

If you compare the data before and after 7.4, it appears the `Region` and `UserType` columns swapped order as well.