### PR TITLE
Add more detail to Cosmic Exploration achievement sheets

### DIFF
--- a/WKSAchievement.yml
+++ b/WKSAchievement.yml
@@ -1,8 +1,12 @@
 name: WKSAchievement
+displayField: Description
 fields:
-  - name: Unknown0
+  - name: Description
   - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
+  - name: RewardItem
+    type: link
+    targets: [WKSAchievementRewardItem]
+  - name: RewardAmount
   - name: Unknown4
-  - name: Unknown5
+  - name: Category
+    comment: Seems to be 1 for Daily and 2 for Standard

--- a/WKSAchievementDailyDefine.yml
+++ b/WKSAchievementDailyDefine.yml
@@ -16,3 +16,8 @@ fields:
     type: array
     count: 4
   - name: SuccessPointsRequired
+relations:
+  Reward:
+    - RequiredQuest
+    - RewardItem
+    - RewardQuantity

--- a/WKSAchievementDailyDefine.yml
+++ b/WKSAchievementDailyDefine.yml
@@ -1,20 +1,18 @@
 name: WKSAchievementDailyDefine
 fields:
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
+  - name: RequiredQuest
+    type: array
+    count: 4
+    fields:
+      - type: link
+        targets: [Quest]
   - name: RewardItem
     type: array
-    count: 2
+    count: 4
     fields:
       - type: link
         targets: [Item]
-  - name: Unknown4
-  - name: Unknown5
-  - name: SuccessPointsRequired
-    type: array
-    count: 2
-  - name: Unknown6
-  - name: Unknown7
   - name: RewardQuantity
+    type: array
+    count: 4
+  - name: SuccessPointsRequired

--- a/WKSAchievementRewardItem.yml
+++ b/WKSAchievementRewardItem.yml
@@ -3,5 +3,7 @@ fields:
   - name: Item
     type: link
     targets: [Item]
-  - name: Unknown1
+  - name: ToolClass
+    type: link
+    targets: [WKSCosmoToolClass]
   - name: Unknown2


### PR DESCRIPTION
Sorry I batched these together, but it didn't make much sense to do one pull request per sheet IMO.

* Change Unknown1 in WKSAchievementRewardItem to be a link to WKSCosmoToolClass; for example WKSAchievement#110 ("Complete 5 unique miner missions on Phaenna.") rewards 75 of WKSAchievementRewardItem#35, which in turn links back to WKSCosmoToolClass#9 (miner's tool).
* Fix-up structure of WKSAchievementDailyDefine; this layout of this sheet seems to be more accurately represented by changing the array count of the RewardItem and RewardQuantity field to be 4.
* Change Unknown0 through Unknown3 in WKSAchievementDailyDefine to be array of Quest links; these fields (again, assuming an array count of 4) line up with the Quest IDs for "A Cosmic Homecoming" and "Go Forth, Brave Explorers", so I grouped them in an array called RequiredQuests.
* Swap RewardQuantity and SuccessPointsRequired in WKSAchievementDailyDefine; after comparing the values with the ones visible in the in-game window, the RewardQuantity and SuccessPointsRequired fields seem to be the wrong way around. So I swapped the names to be more accurate lol.
* Unknown5 in WKSAchievement seems to differentiate between dailies and standard achievements (see field comment).