### PR TITLE
Fix ItemCosts relation in SpecialShop

### DIFF
--- a/SpecialShop.yml
+++ b/SpecialShop.yml
@@ -62,7 +62,7 @@ fields:
       ItemCosts:
         - ItemCost
         - CurrencyCost
-        - HqCost
+        - CostType
         - CollectabilityCost
   - name: Quest
     type: link


### PR DESCRIPTION
The field was renamed in #162, which is causing build errors now.