### PR TITLE
Fill out Crystalline Conflict roulette columns

### DIFF
--- a/ContentFinderCondition.yml
+++ b/ContentFinderCondition.yml
@@ -42,8 +42,8 @@ fields:
   - name: Unknown24
   - name: Unknown25
   - name: Unknown26
-  - name: Unknown27
-  - name: Unknown28
+  - name: CrystallineConflictCasualRoulette
+  - name: CrystallineConflictRankedRoulette
   - name: ShortCode
   - name: Unknown29
     comment: "This would show Addon#102618, if not 0, but the row is empty."


### PR DESCRIPTION
We were missing columns used to filter out CC duties for these roulettes, this roughly corresponds to their position in the ContentRoulette sheet and also appear to only be true for the expected duties.