### PR TITLE
Add Name field to NpcYell

### DIFF
--- a/NpcYell.yml
+++ b/NpcYell.yml
@@ -4,7 +4,9 @@ fields:
   - name: Text
   - name: Unknown6
   - name: BalloonTime
-  - name: Unknown0
+  - name: Name
+    type: link
+    targets: [ENpcResident, BNpcName]
   - name: Unknown7
   - name: Unknown8
   - name: OutputType


### PR DESCRIPTION
This is used to fill out a field in the packet, and corresponds to the name of the NPC yelling.