### PR TITLE
Fill out remaining unknowns on HousingLandSet

### DIFF
--- a/HousingLandSet.yml
+++ b/HousingLandSet.yml
@@ -4,10 +4,10 @@ fields:
     type: array
     count: 60
     fields:
-      - name: UnknownRange1
+      - name: MapRange
       - name: PlacardId
-      - name: UnknownRange2
+      - name: RoomExit
       - name: InitialPrice
       - name: PlotSize
-  - name: UnknownRange1
-  - name: UnknownRange2
+  - name: MainApartment
+  - name: SubdivisionApartment


### PR DESCRIPTION
These unknowns are pointing to a few MapRanges and PopRanges, I'm unsure what the map ranges are for but the pop ranges are probably used for exiting houses..