### PR TITLE
Update GroupPoseFrame, GroupPoseStamp

### DIFF
--- a/GroupPoseFrame.yml
+++ b/GroupPoseFrame.yml
@@ -4,11 +4,35 @@ fields:
   - name: Text
   - name: GridText
   - name: Unknown0
-  - name: Unknown5
+  - name: UnlockCriteria
+    type: link
+    condition:
+      switch: UnlockType
+      cases:
+        1: [Quest]
+        3: [InstanceContent] # Unlocked
+        4: [InstanceContent] # Completed
+        5: [Emote]
+        6: [Companion]
+        7: [Mount]
+        8: [Ornament]
   - name: Unknown1
   - name: Image
     type: icon
   - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown6
+  - name: Festival
+    type: link
+    targets: [Festival]
+  - name: SortKey
+  - name: UnlockType
+    comment: |
+      1 = Quest
+      2 = UnlockLink
+      3 = InstanceContent unlocked
+      4 = InstanceContent completed
+      5 = Emote unlocked
+      6 = Companion unlocked
+      7 = Mount unlocked
+      8 = Ornament unlocked
+      9 = FramersKit unlocked
+      10 = Always available

--- a/GroupPoseStamp.yml
+++ b/GroupPoseStamp.yml
@@ -2,16 +2,40 @@ name: GroupPoseStamp
 displayField: Name
 fields:
   - name: Name
-  - name: Unknown0
+  - name: UnlockCriteria
+    type: link
+    condition:
+      switch: UnlockType
+      cases:
+        1: [Quest]
+        3: [InstanceContent] # Unlocked
+        4: [InstanceContent] # Completed
+        5: [Emote]
+        6: [Companion]
+        7: [Mount]
+        8: [Ornament]
   - name: StampIcon
     type: icon
   - name: Unknown1
   - name: Category
     type: link
     targets: [GroupPoseStampCategory]
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
+  - name: Festival
+    type: link
+    targets: [Festival]
+  - name: SortKey
+  - name: UnlockType
+    comment: |
+      1 = Quest
+      2 = UnlockLink
+      3 = InstanceContent unlocked
+      4 = InstanceContent completed
+      5 = Emote unlocked
+      6 = Companion unlocked
+      7 = Mount unlocked
+      8 = Ornament unlocked
+      9 = FramersKit unlocked
+      10 = Always available
   - name: Unknown5
   - name: Unknown6
   - name: Unknown7


### PR DESCRIPTION
They've activated the [Fan Festival 2026 Group Pose Frames & Stickers](https://eu.finalfantasyxiv.com/lodestone/topics/detail/24e8915ece5b2ac79dc67cb83576d99f399591df) today, so I checked how they do it.
Turns out the server sends a Festival with Id 120. :)