### PR TITLE
Group IKDFishParam content bonuses

### DIFF
--- a/IKDFishParam.yml
+++ b/IKDFishParam.yml
@@ -5,6 +5,8 @@ fields:
     type: link
     targets: [FishParameter]
   - name: IKDContentBonus
-    type: link
-    targets: [IKDContentBonus]
-  - name: Unknown0
+    type: array
+    count: 2
+    fields:
+      - type: link
+        targets: [IKDContentBonus]


### PR DESCRIPTION
Groups the two IKDContentBonus references in IKDFishParam into an array. The second column was previously named Unknown0 but also points to IKDContentBonus.

Before:
<img width="920" height="531" alt="QQ20260428-111525" src="https://github.com/user-attachments/assets/44d809f9-b71d-43e4-94cb-66cf62dd6628" />

After:
<img width="918" height="529" alt="QQ20260428-111424" src="https://github.com/user-attachments/assets/af6b2f01-c2a2-451d-aff1-3c752b4f8ba7" />
