### PR TITLE
Name IKDFishParam bonus objective links

### DIFF
--- a/IKDFishParam.yml
+++ b/IKDFishParam.yml
@@ -4,9 +4,9 @@ fields:
   - name: Fish
     type: link
     targets: [FishParameter]
-  - name: IKDContentBonus
-    type: array
-    count: 2
-    fields:
-      - type: link
-        targets: [IKDContentBonus]
+  - name: PartyBonus
+    type: link
+    targets: [IKDContentBonus]
+  - name: IndividualBonus
+    type: link
+    targets: [IKDContentBonus]


### PR DESCRIPTION
Names the two IKDContentBonus links in IKDFishParam separately.

The first bonus column corresponds to party bonus objectives, and the second bonus column corresponds to individual bonus objectives.