### PR TITLE
Fix CSBonusContentIdentifier Content link case

### DIFF
--- a/CSBonusContentIdentifier.yml
+++ b/CSBonusContentIdentifier.yml
@@ -7,7 +7,7 @@ fields:
       switch: ContentLinkType
       cases:
         1: [InstanceContent]
-        2: [GoldSaucerContent]
+        2: [GFateType]
         3: [TerritoryType]
         4: [MobHuntOrderType]
         5: [TreasureHuntRank]


### PR DESCRIPTION
This change fixes one of the cases used by the Content field in CSBonusContentIdentifier. Case 2 links to GFateType, not GoldSaucerContent.