### PR TITLE
name Status field that specifies overwrite/exclusivity behavior

### DIFF
--- a/Status.yml
+++ b/Status.yml
@@ -10,7 +10,7 @@ fields:
     type: link
     targets: [StatusLoopVFX]
   - name: Log
-  - name: Unknown0
+  - name: ExclusionGroup
   - name: MaxStacks
   - name: ClassJobCategory
     type: link


### PR DESCRIPTION
This field has the same value for all of BLM/THM's Thunders, SGE's Eukrasian Dosis III + Eukrasian Dyskrasia, etc. but e.g. not SCH's Bio/Bio 2:

<img width="184" height="123" alt="image" src="https://github.com/user-attachments/assets/b88c0372-44f4-406d-97d6-57c41a472328" />
