### PR TITLE
Add modelId to Item fields

### DIFF
--- a/Item.yml
+++ b/Item.yml
@@ -12,7 +12,9 @@ fields:
   - name: Pronoun
   - name: Article
   - name: ModelMain
+    type: modelId
   - name: ModelSub
+    type: modelId
   - name: DamagePhys
   - name: DamageMag
   - name: Delayms


### PR DESCRIPTION
For some reason modelId isn't used *anywhere* in the schema despite EXDViewer and Alpha both supporting it... whoops!

<img width="570" height="689" alt="image" src="https://github.com/user-attachments/assets/6ca86d2c-8ea8-4c44-acfb-3bb0c7fa898a" />
