### PR TITLE
Fix Trait.ClassJobCategory

### DIFF
--- a/Trait.yml
+++ b/Trait.yml
@@ -11,10 +11,10 @@ fields:
   - name: ClassJob
     type: link
     targets: [ClassJob]
-  - name: Unknown_70
-  - name: Level
   - name: ClassJobCategory
     type: link
     targets: [ClassJobCategory]
+  - name: Level
+  - name: Unknown2
   - name: Unknown0
   - name: Unknown1


### PR DESCRIPTION
The column `ClassJobCategory` is actually where `Unknown_70` is:

<img width="1034" height="643" alt="Screenshot" src="https://github.com/user-attachments/assets/2cab9766-0dc8-41a1-8827-a01e23fc6929" />
