### PR TITLE
remove invalid ContentFinderConditionTransient link

### DIFF
--- a/ContentFinderCondition.yml
+++ b/ContentFinderCondition.yml
@@ -67,9 +67,7 @@ fields:
   - name: JournalGenre
     type: link
     targets: [JournalGenre]
-  - name: Transient
-    type: link
-    targets: [ContentFinderConditionTransient]
+  - name: Unknown59
   - name: Image
     type: icon
   - name: Icon


### PR DESCRIPTION
The ContentFinderConditionTransient rows have the same ID as their corresponding ContentFinderCondition rows. I'm not sure what the values in the "Transient" column are, but they are not ContentFinderConditionTransient row IDs. 
<img width="607" height="154" alt="image" src="https://github.com/user-attachments/assets/d3d05f7d-67ff-4691-b973-6684d6f5431e" />
