### PR TITLE
Rename 'Unknown0' field to 'Radius' in ModelChara

### DIFF
--- a/ModelChara.yml
+++ b/ModelChara.yml
@@ -1,6 +1,6 @@
 name: ModelChara
 fields:
-  - name: Unknown0
+  - name: Radius
   - name: Unknown1
   - name: Unknown15
   - name: Model


### PR DESCRIPTION
If present (not 0), the value in this field appears to be multiplied by BNpcBase.Scale to determine [HitboxRadius](https://github.com/aers/FFXIVClientStructs/blob/cba4c1581157ff8e2dc33390e59d03c8233e85cf/FFXIVClientStructs/FFXIV/Client/Game/Object/GameObject.cs#L42) for BNpcs. Otherwise (if 0), ModelSkeleton.Radius seems to be used instead. The result will be stored in [FFXIVClientStructs.FFXIV.Client.Game.Character.ModelContainer.UnscaledRadius](https://github.com/aers/FFXIVClientStructs/blob/cba4c1581157ff8e2dc33390e59d03c8233e85cf/FFXIVClientStructs/FFXIV/Client/Game/Character/ModelContainer.cs#L23)

It's also referenced in `Client::Game::Character::ModelContainer::CalculateUnscaledRadius`

Examples below

<details><summary>Kefka (DMU P2 version)</summary>
<h3>Kefka (DMU P2 version)</h3>

In-game hitbox radius: **6.02**
https://exd.camora.dev/sheet/BNpcBase#R19506
Scale: 3.5
https://exd.camora.dev/sheet/ModelChara#R4967
Radius: 1.72
Model: 459
https://exd.camora.dev/sheet/ModelSkeleton#R459
Radius: 1
3.5 * 1.72 = **6.02**
</details>

<details><summary>Exdeath (DMU P3 version)</summary>
<h3>Exdeath (DMU P3 version)</h3>

In-game hitbox radius: **3.8**
https://exd.camora.dev/sheet/BNpcBase#R19509
Scale: 3.8
https://exd.camora.dev/sheet/ModelChara#R326
Radius: 0
Model: 109
https://exd.camora.dev/sheet/ModelSkeleton#R109
Radius: 1
3.8 * 1 = **3.8**
</details>

<details><summary>Chaos (DMU P3 version)</summary>
<h3>Chaos (DMU P3 version)</h3>

In-game hitbox radius: **6**
https://exd.camora.dev/sheet/BNpcBase#R19508
Scale: 1
https://exd.camora.dev/sheet/ModelChara#R5010
Radius: 6
Model: 295
https://exd.camora.dev/sheet/ModelSkeleton#R295
Radius: 4.5
1 * 6 = **6**
</details>

<details><summary>Hephaistos (P8N)</summary>
<h3>Hephaistos (P8N)</h3>

In-game hitbox radius: **10**
https://exd.camora.dev/sheet/BNpcBase#R15045
Scale: 0.8
https://exd.camora.dev/sheet/ModelChara#R3621
Radius: 0
Model: 790
https://exd.camora.dev/sheet/ModelSkeleton#R790
Radius: 12.5
0.8 * 12.5 = **10**
</details>