### PR TITLE
Update Ornament

### DIFF
--- a/Ornament.yml
+++ b/Ornament.yml
@@ -17,6 +17,8 @@ fields:
     type: icon
   - name: Transient
   - name: Order
-  - name: AttachmentPoint
+  - name: CustomizeGroup
+    type: link
+    targets: [OrnamentCustomizeGroup]
   - name: Unknown3
   - name: Unknown4

--- a/OrnamentCustomizeGroup.yml
+++ b/OrnamentCustomizeGroup.yml
@@ -2,10 +2,8 @@ name: OrnamentCustomizeGroup
 fields:
   - name: Customize
     type: array
-    count: 19
+    count: 21
     fields:
       - type: link
         targets: [OrnamentCustomize]
-  - name: Unknown19
-  - name: Unknown20
-  - name: Unknown18
+  - name: AttachmentPoint


### PR DESCRIPTION
The column AttachmentPoint is actually an OrnamentCustomizeGroup RowId.

I found that OrnamentCustomizeGroup.Unknown18 is passed around and eventually set to [Client::Graphics::Render::Skeleton::BoneIndexMask.SkeletonIdxBoneIdx](https://github.com/aers/FFXIVClientStructs/blob/3f6a030/FFXIVClientStructs/FFXIV/Client/Graphics/Render/Skeleton.cs#L54), so that's what I called AttachmentPoint now.