### PR TITLE
Fix a bunch of EObj columns

### DIFF
--- a/EObj.yml
+++ b/EObj.yml
@@ -9,8 +9,10 @@ fields:
   - name: PopType
   - name: Invisibility
   - name: Unknown0
-  - name: Unknown11
-  - name: Unknown12
+  - name: AdditionalInteractRangeX
+    comment: Used in EventFramework.CheckInteractRangeEx.
+  - name: AdditionalInteractRangeY
+    comment: Used in EventFramework.CheckInteractRangeEx.
   - name: Unknown1
   - name: Unknown2
   - name: Unknown3
@@ -19,9 +21,11 @@ fields:
   - name: Unknown6
   - name: Unknown7
   - name: Unknown8
-  - name: EyeCollision
-  - name: DirectorControl
-  - name: Target
+  - name: Targetable
   - name: Unknown9
-  - name: AddedIn53
   - name: Unknown10
+  - name: Unknown11
+  - name: LuaSetup
+    comment: If set, EObjs managed by a QuestEventHandler calls into Lua first to set up initial shared group timeline state. This can be used by Quest scripting to animate an SGB during a specific sequence of the quest.
+  - name: SharedTimelineStateUnknown
+    comment: Not sure what the true meaning of this field means, but its checked within EventObject.UpdateSharedTimelineState.


### PR DESCRIPTION
These seem to have been grand-fathered in from somewhere, but they're just kinda wrong. "Target" I think is meant to be an indication of whether the EObj is spawned and is targetable, but it's not on the right column. I have no idea what EyeCollision/DirectorControl means nor did Ghidra point to me anything obvious, so I removed those for now.

I did figure out a few more fields though, which I have now documented. The only thing I'm somewhat unsure about is the new Targetable column, I only figured that out through process-of-elimination after cross-referencing different SpawnObject packets.