### PR TITLE
Update Festival, HalloweenNpcSelect

### DIFF
--- a/Festival.yml
+++ b/Festival.yml
@@ -2,5 +2,7 @@ name: Festival
 displayField: Name
 fields:
   - name: Name
-  - name: Unknown1
-  - name: Unknown0
+  - name: IsAllSaintsWake
+  - name: WeatherRate
+    type: link
+    targets: [WeatherRate]

--- a/HalloweenNpcSelect.yml
+++ b/HalloweenNpcSelect.yml
@@ -2,13 +2,18 @@ name: HalloweenNpcSelect
 fields:
   - name: Description
   - name: Unknown1
-  - name: Unknown2
+  - name: RequiredQuest
+    type: link
+    targets: [Quest]
   - name: PreviewIcon
     type: icon
   - name: Transformation
     type: link
     targets: [Transformation]
-  - name: Unknown5
+  - name: Festival
+    type: link
+    targets: [Festival]
+    comment: The Festival where this option became available.
   - name: Expansion
     type: link
     targets: [ExVersion]


### PR DESCRIPTION
The Festival column IsAllSaintsWake is used in AgentHalloweenNpcSelect, to check if an active Festival is the Halloween event (All Saint's Wake).