### PR TITLE
Update Attributive and sheets used by the noun system

### DIFF
--- a/Aetheryte.yml
+++ b/Aetheryte.yml
@@ -6,7 +6,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Unknown1

--- a/Attributive.yml
+++ b/Attributive.yml
@@ -2,12 +2,12 @@ name: Attributive
 fields:
   - name: JapaneseSingularDemonstrative
   - name: JapanesePluralDemonstrative
-  - name: EnglishArticleSingularConsonant
-  - name: EnglishArticleGenericConsonant
-  - name: EnglishArticlePluralConsonant
-  - name: EnglishArticleSingularVowel
-  - name: EnglishArticleGenericVowel
-  - name: EnglishArticlePluralVowel
+  - name: EnglishSingularConsonant
+  - name: EnglishGenericConsonant
+  - name: EnglishPluralConsonant
+  - name: EnglishSingularVowel
+  - name: EnglishGenericVowel
+  - name: EnglishPluralVowel
   - name: GermanNominativeMasculine
   - name: GermanNominativeFeminine
   - name: GermanNominativeNeutral
@@ -24,20 +24,20 @@ fields:
   - name: GermanAccusativeFeminine
   - name: GermanAccusativeNeutral
   - name: GermanAccusativePlural
-  - name: FrenchArticleSingular
-  - name: FrenchArticleSingularMasculine
-  - name: FrenchArticlePluralMasculine
-  - name: FrenchArticleSingularMasculineElided
-  - name: FrenchArticlePluralMasculineElided
-  - name: FrenchArticleSingularElided
-  - name: FrenchArticlePluralElided
-  - name: FrenchArticleSingularMasculineContracted
-  - name: FrenchArticlePluralMasculineContracted
-  - name: FrenchArticleSingularFeminine
-  - name: FrenchArticlePluralFeminine
-  - name: FrenchArticleSingularFeminineElided
-  - name: FrenchArticlePluralFeminineElided
-  - name: FrenchArticleSingularElidedAlt
-  - name: FrenchArticlePluralElidedAlt
-  - name: FrenchArticleSingularNeutral
-  - name: FrenchArticlePluralNeutral
+  - name: FrenchMasculineConsonantBase
+  - name: FrenchMasculineConsonantSingular
+  - name: FrenchMasculineConsonantPlural
+  - name: FrenchMasculineConsonantMass
+  - name: FrenchMasculineVowelBase
+  - name: FrenchMasculineVowelSingular
+  - name: FrenchMasculineVowelPlural
+  - name: FrenchMasculineVowelMass
+  - name: FrenchFeminineConsonantBase
+  - name: FrenchFeminineConsonantSingular
+  - name: FrenchFeminineConsonantPlural
+  - name: FrenchFeminineConsonantMass
+  - name: FrenchFeminineVowelBase
+  - name: FrenchFeminineVowelSingular
+  - name: FrenchFeminineVowelPlural
+  - name: FrenchFeminineVowelMass
+  - name: Unknown40

--- a/Attributive.yml
+++ b/Attributive.yml
@@ -1,13 +1,13 @@
 name: Attributive
 fields:
-  - name: JapaneseSingularDemonstrative
-  - name: JapanesePluralDemonstrative
-  - name: EnglishSingularConsonant
-  - name: EnglishGenericConsonant
-  - name: EnglishPluralConsonant
-  - name: EnglishSingularVowel
-  - name: EnglishGenericVowel
-  - name: EnglishPluralVowel
+  - name: JapaneseDemonstrative
+  - name: JapaneseDemonstrativePlural
+  - name: EnglishConsonantSingular
+  - name: EnglishConsonantGeneric
+  - name: EnglishConsonantPlural
+  - name: EnglishVowelSingular
+  - name: EnglishVowelGeneric
+  - name: EnglishVowelPlural
   - name: GermanNominativeMasculine
   - name: GermanNominativeFeminine
   - name: GermanNominativeNeutral

--- a/BNpcName.yml
+++ b/BNpcName.yml
@@ -6,6 +6,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/BuddyEquip.yml
+++ b/BuddyEquip.yml
@@ -7,7 +7,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: ModelTop

--- a/Companion.yml
+++ b/Companion.yml
@@ -6,7 +6,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Model

--- a/DeepDungeonDemiclone.yml
+++ b/DeepDungeonDemiclone.yml
@@ -5,11 +5,11 @@ fields:
   - name: Plural
   - name: TitleCase
   - name: Description
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
-  - name: Unknown8
-  - name: Unknown9
+  - name: Adjective
+  - name: PossessivePronoun
+  - name: StartsWithVowel
+  - name: Countability
+  - name: Pronoun
+  - name: Article
   - name: Icon
     type: icon

--- a/DeepDungeonEquipment.yml
+++ b/DeepDungeonEquipment.yml
@@ -8,7 +8,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Icon

--- a/DeepDungeonItem.yml
+++ b/DeepDungeonItem.yml
@@ -8,7 +8,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Icon

--- a/DeepDungeonMagicStone.yml
+++ b/DeepDungeonMagicStone.yml
@@ -8,7 +8,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Icon

--- a/ENpcResident.yml
+++ b/ENpcResident.yml
@@ -7,7 +7,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Map

--- a/EObjName.yml
+++ b/EObjName.yml
@@ -6,6 +6,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/EurekaAetherItem.yml
+++ b/EurekaAetherItem.yml
@@ -7,6 +7,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/EventItem.yml
+++ b/EventItem.yml
@@ -7,7 +7,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Unknown1

--- a/GCRankGridaniaFemaleText.yml
+++ b/GCRankGridaniaFemaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GCRankGridaniaMaleText.yml
+++ b/GCRankGridaniaMaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GCRankLimsaFemaleText.yml
+++ b/GCRankLimsaFemaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GCRankLimsaMaleText.yml
+++ b/GCRankLimsaMaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GCRankUldahFemaleText.yml
+++ b/GCRankUldahFemaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GCRankUldahMaleText.yml
+++ b/GCRankUldahMaleText.yml
@@ -8,6 +8,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown1
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/GatheringPointName.yml
+++ b/GatheringPointName.yml
@@ -6,6 +6,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/Glasses.yml
+++ b/Glasses.yml
@@ -8,7 +8,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown_70_4
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Model

--- a/GlassesStyle.yml
+++ b/GlassesStyle.yml
@@ -7,7 +7,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown_70_4
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Icon

--- a/GrandCompany.yml
+++ b/GrandCompany.yml
@@ -1,15 +1,15 @@
 name: GrandCompany
-displayField: Name
+displayField: Singular
 fields:
-  - name: Name
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
+  - name: Singular
+  - name: Plural
+  - name: NamePrepositional
+  - name: Adjective
+  - name: PossessivePronoun
+  - name: StartsWithVowel
+  - name: Countability
+  - name: Pronoun
+  - name: Article
   - name: MonsterNote
     type: link
     targets: [MonsterNote]

--- a/HousingPreset.yml
+++ b/HousingPreset.yml
@@ -5,7 +5,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: ExteriorRoof

--- a/Item.yml
+++ b/Item.yml
@@ -8,7 +8,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: ModelMain

--- a/MJIName.yml
+++ b/MJIName.yml
@@ -6,6 +6,6 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article

--- a/Mount.yml
+++ b/Mount.yml
@@ -6,7 +6,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: WhistlePath

--- a/Ornament.yml
+++ b/Ornament.yml
@@ -6,7 +6,7 @@ fields:
   - name: Adjective
   - name: PossessivePronoun
   - name: StartsWithVowel
-  - name: Unknown0
+  - name: Countability
   - name: Pronoun
   - name: Article
   - name: Model

--- a/PlaceName.yml
+++ b/PlaceName.yml
@@ -3,14 +3,14 @@ displayField: Name
 fields:
   - name: Name
   - name: NameNoArticle
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
+  - name: NamePrepositional
+  - name: Adjective
+  - name: PossessivePronoun
+  - name: StartsWithVowel
+  - name: Countability
+  - name: Pronoun
+  - name: Article
+  - name: Order
   - name: Unknown8
   - name: MapCondition
     type: link

--- a/Treasure.yml
+++ b/Treasure.yml
@@ -1,14 +1,14 @@
 name: Treasure
 displayField: SGB
 fields:
-  - name: Unknown0
-  - name: Unknown1
-  - name: Unknown2
-  - name: Unknown3
-  - name: Unknown4
-  - name: Unknown5
-  - name: Unknown6
-  - name: Unknown7
+  - name: Singular
+  - name: Plural
+  - name: Adjective
+  - name: PossessivePronoun
+  - name: StartsWithVowel
+  - name: Countability
+  - name: Pronoun
+  - name: Article
   - name: SGB
     type: link
     targets: [ExportedSG]


### PR DESCRIPTION
Don't know how GrandCompany and PlaceName work with the noun system.
Other than that, this looks much better, imo.
I worked on this while fixing the `frnoun` macro for Dalamud (https://github.com/goatcorp/Dalamud/pull/2908).