### PR TITLE
remove display field from ItemSortCategory

### DIFF
--- a/ItemSortCategory.yml
+++ b/ItemSortCategory.yml
@@ -1,4 +1,3 @@
 name: ItemSortCategory
-displayField: Param
 fields:
   - name: Param


### PR DESCRIPTION
This removes "Param" as the display field for a few reasons:
- the param values are integers, so the display doesn't add value
- displaying the "param" value rather than the raw sheet value is confusing, because  you'd expect the value being displayed to be the value in the sheet, which isn't always the case (using Wolf Marks as an example):
<img width="152" height="110" alt="image" src="https://github.com/user-attachments/assets/8c1b7e3f-a16d-4c88-b7e3-9941544d771c" />

- it prevents the user from being able to search the sheet using the ItemSortCategory ID:
<img width="288" height="254" alt="image" src="https://github.com/user-attachments/assets/1401e742-93a9-474e-b89b-21f142279ec2" />

