### PR TITLE
Update Beastmaster schemas

### DIFF
--- a/XBMActionEffectType.yml
+++ b/XBMActionEffectType.yml
@@ -1,3 +1,3 @@
 name: XBMActionEffectType
 fields:
-- name: Unknown0
+  - name: Name

--- a/XBMActionTarget.yml
+++ b/XBMActionTarget.yml
@@ -1,3 +1,3 @@
 name: XBMActionTarget
 fields:
-- name: Unknown0
+  - name: Name

--- a/XBMBattleDetail.yml
+++ b/XBMBattleDetail.yml
@@ -1,24 +1,24 @@
 name: XBMBattleDetail
 fields:
-- name: Name
-  type: link
-  targets: [BNpcName]
-- name: Unknown1
-  type: icon
-- name: Unknown2
-  type: link
-  targets: [XBMBattleDetailAction]
-- name: Unknown3
-  type: link
-  targets: [XBMBattleDetailAction]
-- name: Resist
-  type: link
-  targets: [BNpcResist]
-- name: Unknown5
-- name: Unknown6
-- name: Unknown7
-- name: Unknown8
-- name: Unknown9
-- name: Element
-  type: link
-  targets: [XBMElement]
+  - name: Name
+    type: link
+    targets: [BNpcName]
+  - name: Image
+    type: icon
+  - name: Unknown2
+    type: link
+    targets: [XBMBattleDetailAction]
+  - name: Unknown3
+    type: link
+    targets: [XBMBattleDetailAction]
+  - name: Resist
+    type: link
+    targets: [BNpcResist]
+  - name: Unknown5
+  - name: Unknown6
+  - name: Unknown7
+  - name: Unknown8
+  - name: Unknown9
+  - name: Element
+    type: link
+    targets: [XBMElement]

--- a/XBMPet.yml
+++ b/XBMPet.yml
@@ -1,26 +1,31 @@
 name: XBMPet
 fields:
-- name: Unknown0
-- name: Unknown1
-- name: Unknown2
-- name: Unknown3
-- name: Pet
-  type: link
-  targets: [Pet]
-- name: Action
-  type: link
-  targets: [Action]
-- name: Location
-  type: link
-  condition:
-    switch: LocationKey
-    cases:
-      1: [PlaceName]
-      2: [ContentFinderCondition]
-- name: Unknown7
-- name: Unknown8
-- name: Unknown9
-- name: LocationKey
-- name: Unknown11 # uses the same indexer as BNpcResist.Unknown0
-  type: array
-  count: 11
+  - name: Description
+  - name: Trick
+  - name: TemperedRelease
+  - name: Image
+  - name: Pet
+    type: link
+    targets: [Pet]
+  - name: AutoAttack
+    type: link
+    targets: [Action]
+  - name: Location
+    type: link
+    condition:
+      switch: LocationKey
+      cases:
+        1: [PlaceName]
+        2: [ContentFinderCondition]
+  - name: Unknown7
+  - name: Unknown8
+  - name: Unknown9
+  - name: LocationKey
+  - name: Unknown12
+  - name: Unknown13
+  - name: Unknown14
+  - name: Unknown15
+  - name: Unknown16
+  - name: Unknown11 # uses the same indexer as BNpcResist.Unknown0
+    type: array
+    count: 11


### PR DESCRIPTION
Names some fields for Beastmaster (XBM) sheets and fixes formatting.

### Notes
* Beast name is the Pet "Name"
* Trick & Tempered Release actions are pet abilities 0 & 1
  * The names lives on the Action (linked to the Pet Ability)
  * The descriptions lives on XBMPet
* The beast aspect lives on the XBMPet AutoAttack Action "Aspect"

### Unknown
* Classification (text lives in Addon but not clearly linked to the beast)
  * Based on the Beast Mode tooltip, Classification should also identify which Beast Mode skill is provided