### PR TITLE
Update XBMPet for 7.56

### DIFF
--- a/XBMPet.yml
+++ b/XBMPet.yml
@@ -21,6 +21,11 @@ fields:
 - name: Unknown8
 - name: Unknown9
 - name: LocationKey
+- name: Unknown12
+- name: Unknown13
+- name: Unknown14
+- name: Unknown15
+- name: Unknown16
 - name: Unknown11 # uses the same indexer as BNpcResist.Unknown0
   type: array
   count: 11


### PR DESCRIPTION
7.56 added five uint8 columns to XBMPet at offsets 28-32, which pushed the eleven bools from offsets 28-38 to 33-43 and grew the sheet from 22 to 27 columns. The current definition still describes 22 columns, so the column hash check fails and Lumina.Excel returns null for the sheet.

This adds the five new fields as Unknown12 through Unknown16 between LocationKey and the existing Unknown11 array, following the offset ordering of the sheet. The existing Unknown numbering is left alone.

Verified against game version 2026.09.01.0000.0000: the raw sheet reports 27 columns with the five uint8 at offsets 28-32 and the bools at 33-43, and with the updated definition the sheet loads and rows resolve as expected (row 1 links to Pet 47, Cu Sith).

I left .github/columns.yml untouched since that appears to be updated by the maintainers when new column data is published.